### PR TITLE
Add xUnit test project with unit tests for models, services, and DbContext

### DIFF
--- a/Tests/DotNetSamples.Tests/DotNetSamples.Tests.csproj
+++ b/Tests/DotNetSamples.Tests/DotNetSamples.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../AspNetCore/Angular/AdHocReporting/AdHocReporting.Server/AdHocReporting.Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/DotNetSamples.Tests/Models/CustomerTests.cs
+++ b/Tests/DotNetSamples.Tests/Models/CustomerTests.cs
@@ -1,0 +1,54 @@
+using EqDemo.Models;
+using FluentAssertions;
+
+namespace DotNetSamples.Tests.Models;
+
+public class CustomerTests
+{
+    [Fact]
+    public void Properties_ShouldRoundTrip()
+    {
+        var customer = new Customer
+        {
+            Id = "ALFKI",
+            CompanyName = "Alfreds Futterkiste",
+            Address = "Obere Str. 57",
+            City = "Berlin",
+            Region = null,
+            PostalCode = "12209",
+            Country = "Germany",
+            ContactName = "Maria Anders",
+            ContactTitle = "Sales Representative",
+            Phone = "030-0074321",
+            Fax = "030-0076545"
+        };
+
+        customer.Id.Should().Be("ALFKI");
+        customer.CompanyName.Should().Be("Alfreds Futterkiste");
+        customer.Address.Should().Be("Obere Str. 57");
+        customer.City.Should().Be("Berlin");
+        customer.Region.Should().BeNull();
+        customer.PostalCode.Should().Be("12209");
+        customer.Country.Should().Be("Germany");
+        customer.ContactName.Should().Be("Maria Anders");
+        customer.ContactTitle.Should().Be("Sales Representative");
+        customer.Phone.Should().Be("030-0074321");
+        customer.Fax.Should().Be("030-0076545");
+    }
+
+    [Fact]
+    public void DefaultValues_ShouldBeNull()
+    {
+        var customer = new Customer();
+
+        customer.Id.Should().BeNull();
+        customer.CompanyName.Should().BeNull();
+        customer.Address.Should().BeNull();
+        customer.City.Should().BeNull();
+        customer.Country.Should().BeNull();
+        customer.ContactName.Should().BeNull();
+        customer.ContactTitle.Should().BeNull();
+        customer.Phone.Should().BeNull();
+        customer.Fax.Should().BeNull();
+    }
+}

--- a/Tests/DotNetSamples.Tests/Models/EmployeeTests.cs
+++ b/Tests/DotNetSamples.Tests/Models/EmployeeTests.cs
@@ -1,0 +1,158 @@
+using EqDemo.Models;
+using FluentAssertions;
+
+namespace DotNetSamples.Tests.Models;
+
+public class EmployeeTests
+{
+    [Fact]
+    public void FullName_ShouldCombineFirstAndLastName()
+    {
+        var employee = new Employee
+        {
+            FirstName = "John",
+            LastName = "Doe"
+        };
+
+        employee.FullName.Should().Be("John Doe");
+    }
+
+    [Fact]
+    public void FullName_ShouldHandleOnlyFirstName()
+    {
+        var employee = new Employee
+        {
+            FirstName = "John",
+            LastName = null
+        };
+
+        employee.FullName.Should().Be("John ");
+    }
+
+    [Fact]
+    public void FullName_ShouldHandleEmptyFirstName()
+    {
+        var employee = new Employee
+        {
+            FirstName = "",
+            LastName = "Doe"
+        };
+
+        employee.FullName.Should().Be("Doe");
+    }
+
+    [Fact]
+    public void FullName_ShouldHandleNullFirstName()
+    {
+        var employee = new Employee
+        {
+            FirstName = null,
+            LastName = "Doe"
+        };
+
+        employee.FullName.Should().Be("Doe");
+    }
+
+    [Fact]
+    public void FullName_ShouldHandleBothNull()
+    {
+        var employee = new Employee
+        {
+            FirstName = null,
+            LastName = null
+        };
+
+        employee.FullName.Should().BeNull();
+    }
+
+    [Fact]
+    public void FullName_ShouldHandleBothEmpty()
+    {
+        var employee = new Employee
+        {
+            FirstName = "",
+            LastName = ""
+        };
+
+        employee.FullName.Should().Be("");
+    }
+
+    [Fact]
+    public void Properties_ShouldRoundTrip()
+    {
+        var hireDate = new DateTime(2020, 6, 15);
+        var birthDate = new DateTime(1990, 3, 20);
+
+        var employee = new Employee
+        {
+            Id = 1,
+            FirstName = "Jane",
+            LastName = "Smith",
+            Title = "Sales Representative",
+            TitleOfCourtesy = "Ms.",
+            BirthDate = birthDate,
+            HireDate = hireDate,
+            Address = "456 Oak Ave",
+            City = "Portland",
+            Region = "OR",
+            PostalCode = "97201",
+            Country = "USA",
+            HomePhone = "(503) 555-1234",
+            Extension = "1234",
+            PhotoPath = "/photos/jane.jpg",
+            Notes = "Experienced sales rep",
+            ReportsTo = 2
+        };
+
+        employee.Id.Should().Be(1);
+        employee.Title.Should().Be("Sales Representative");
+        employee.TitleOfCourtesy.Should().Be("Ms.");
+        employee.BirthDate.Should().Be(birthDate);
+        employee.HireDate.Should().Be(hireDate);
+        employee.Address.Should().Be("456 Oak Ave");
+        employee.City.Should().Be("Portland");
+        employee.Region.Should().Be("OR");
+        employee.PostalCode.Should().Be("97201");
+        employee.Country.Should().Be("USA");
+        employee.HomePhone.Should().Be("(503) 555-1234");
+        employee.Extension.Should().Be("1234");
+        employee.PhotoPath.Should().Be("/photos/jane.jpg");
+        employee.Notes.Should().Be("Experienced sales rep");
+        employee.ReportsTo.Should().Be(2);
+    }
+
+    [Fact]
+    public void Manager_ShouldBeSettable()
+    {
+        var manager = new Employee { Id = 1, FirstName = "Boss", LastName = "Man" };
+        var employee = new Employee
+        {
+            Id = 2,
+            FirstName = "Worker",
+            LastName = "Bee",
+            ReportsTo = 1,
+            Manager = manager
+        };
+
+        employee.Manager.Should().NotBeNull();
+        employee.Manager!.FullName.Should().Be("Boss Man");
+    }
+
+    [Fact]
+    public void Orders_ShouldBeSettable()
+    {
+        var employee = new Employee
+        {
+            Id = 1,
+            FirstName = "Test",
+            LastName = "User",
+            Orders = new List<Order>
+            {
+                new Order { Id = 100 },
+                new Order { Id = 101 }
+            }
+        };
+
+        employee.Orders.Should().HaveCount(2);
+    }
+}

--- a/Tests/DotNetSamples.Tests/Models/OrderDetailTests.cs
+++ b/Tests/DotNetSamples.Tests/Models/OrderDetailTests.cs
@@ -1,0 +1,58 @@
+using EqDemo.Models;
+using FluentAssertions;
+
+namespace DotNetSamples.Tests.Models;
+
+public class OrderDetailTests
+{
+    [Fact]
+    public void Properties_ShouldRoundTrip()
+    {
+        var detail = new OrderDetail
+        {
+            OrderID = 10248,
+            ProductID = 11,
+            UnitPrice = 14.00m,
+            Quantity = 12,
+            Discount = 0.1f
+        };
+
+        detail.OrderID.Should().Be(10248);
+        detail.ProductID.Should().Be(11);
+        detail.UnitPrice.Should().Be(14.00m);
+        detail.Quantity.Should().Be(12);
+        detail.Discount.Should().BeApproximately(0.1f, 0.001f);
+    }
+
+    [Fact]
+    public void DefaultValues_ShouldBeZero()
+    {
+        var detail = new OrderDetail();
+
+        detail.OrderID.Should().Be(0);
+        detail.ProductID.Should().Be(0);
+        detail.UnitPrice.Should().Be(0);
+        detail.Quantity.Should().Be(0);
+        detail.Discount.Should().Be(0);
+    }
+
+    [Fact]
+    public void NavigationProperties_ShouldBeSettable()
+    {
+        var order = new Order { Id = 1 };
+        var product = new Product { Id = 10, Name = "Chai" };
+
+        var detail = new OrderDetail
+        {
+            OrderID = 1,
+            ProductID = 10,
+            Order = order,
+            Product = product
+        };
+
+        detail.Order.Should().NotBeNull();
+        detail.Order!.Id.Should().Be(1);
+        detail.Product.Should().NotBeNull();
+        detail.Product!.Name.Should().Be("Chai");
+    }
+}

--- a/Tests/DotNetSamples.Tests/Models/OrderTests.cs
+++ b/Tests/DotNetSamples.Tests/Models/OrderTests.cs
@@ -1,0 +1,126 @@
+using EqDemo.Models;
+using FluentAssertions;
+
+namespace DotNetSamples.Tests.Models;
+
+public class OrderTests
+{
+    [Fact]
+    public void Name_ShouldFormatIdAndDate()
+    {
+        var order = new Order
+        {
+            Id = 42,
+            OrderDate = new DateTime(2024, 3, 15)
+        };
+
+        order.Name.Should().Be("0042-2024-03-15");
+    }
+
+    [Fact]
+    public void Name_ShouldHandleNullOrderDate()
+    {
+        var order = new Order
+        {
+            Id = 1,
+            OrderDate = null
+        };
+
+        // string.Format with null DateTime? produces empty string for the date part
+        order.Name.Should().Be("0001-");
+    }
+
+    [Fact]
+    public void Name_ShouldPadIdToFourDigits()
+    {
+        var order = new Order
+        {
+            Id = 7,
+            OrderDate = new DateTime(2023, 1, 1)
+        };
+
+        order.Name.Should().StartWith("0007-");
+    }
+
+    [Fact]
+    public void Name_ShouldHandleLargeId()
+    {
+        var order = new Order
+        {
+            Id = 12345,
+            OrderDate = new DateTime(2024, 6, 1)
+        };
+
+        order.Name.Should().Be("12345-2024-06-01");
+    }
+
+    [Fact]
+    public void DefaultValues_ShouldBeNull()
+    {
+        var order = new Order();
+
+        order.CustomerID.Should().BeNull();
+        order.Customer.Should().BeNull();
+        order.EmployeeID.Should().BeNull();
+        order.Employee.Should().BeNull();
+        order.Freight.Should().BeNull();
+        order.ShippedDate.Should().BeNull();
+        order.RequiredDate.Should().BeNull();
+        order.ShipName.Should().BeNull();
+        order.ShipAddress.Should().BeNull();
+        order.ShipCity.Should().BeNull();
+        order.ShipRegion.Should().BeNull();
+        order.ShipPostalCode.Should().BeNull();
+        order.ShipCountry.Should().BeNull();
+    }
+
+    [Fact]
+    public void Properties_ShouldRoundTrip()
+    {
+        var order = new Order
+        {
+            Id = 100,
+            OrderDate = new DateTime(2024, 1, 1),
+            RequiredDate = new DateTime(2024, 1, 15),
+            ShippedDate = new DateTime(2024, 1, 10),
+            Freight = 25.50m,
+            CustomerID = "CUST1",
+            EmployeeID = 5,
+            ShipVia = 2,
+            ShipName = "Test Ship",
+            ShipAddress = "123 Main St",
+            ShipCity = "Seattle",
+            ShipRegion = "WA",
+            ShipPostalCode = "98101",
+            ShipCountry = "USA"
+        };
+
+        order.Id.Should().Be(100);
+        order.Freight.Should().Be(25.50m);
+        order.CustomerID.Should().Be("CUST1");
+        order.EmployeeID.Should().Be(5);
+        order.ShipVia.Should().Be(2);
+        order.ShipName.Should().Be("Test Ship");
+        order.ShipAddress.Should().Be("123 Main St");
+        order.ShipCity.Should().Be("Seattle");
+        order.ShipRegion.Should().Be("WA");
+        order.ShipPostalCode.Should().Be("98101");
+        order.ShipCountry.Should().Be("USA");
+    }
+
+    [Fact]
+    public void Items_ShouldBeSettable()
+    {
+        var order = new Order
+        {
+            Id = 1,
+            Items = new List<OrderDetail>
+            {
+                new OrderDetail { OrderID = 1, ProductID = 10, UnitPrice = 5.0m, Quantity = 2 },
+                new OrderDetail { OrderID = 1, ProductID = 20, UnitPrice = 10.0m, Quantity = 1 }
+            }
+        };
+
+        order.Items.Should().HaveCount(2);
+    }
+}

--- a/Tests/DotNetSamples.Tests/Models/ProductTests.cs
+++ b/Tests/DotNetSamples.Tests/Models/ProductTests.cs
@@ -1,0 +1,87 @@
+using EqDemo.Models;
+using FluentAssertions;
+
+namespace DotNetSamples.Tests.Models;
+
+public class ProductTests
+{
+    [Fact]
+    public void Properties_ShouldRoundTrip()
+    {
+        var product = new Product
+        {
+            Id = 1,
+            Name = "Widget",
+            SupplierID = 5,
+            CategoryID = 3,
+            QuantityPerUnit = "10 boxes x 20 bags",
+            UnitPrice = 18.50m,
+            UnitsInStock = 39,
+            UnitsOnOrder = 10,
+            ReorderLevel = 5,
+            Discontinued = false
+        };
+
+        product.Id.Should().Be(1);
+        product.Name.Should().Be("Widget");
+        product.SupplierID.Should().Be(5);
+        product.CategoryID.Should().Be(3);
+        product.QuantityPerUnit.Should().Be("10 boxes x 20 bags");
+        product.UnitPrice.Should().Be(18.50m);
+        product.UnitsInStock.Should().Be(39);
+        product.UnitsOnOrder.Should().Be(10);
+        product.ReorderLevel.Should().Be(5);
+        product.Discontinued.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DefaultValues_ShouldBeExpected()
+    {
+        var product = new Product();
+
+        product.Id.Should().Be(0);
+        product.Name.Should().BeNull();
+        product.UnitPrice.Should().BeNull();
+        product.UnitsInStock.Should().BeNull();
+        product.UnitsOnOrder.Should().BeNull();
+        product.ReorderLevel.Should().BeNull();
+        product.Discontinued.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Supplier_ShouldBeSettable()
+    {
+        var supplier = new Supplier { Id = 1, CompanyName = "Acme Corp" };
+        var product = new Product
+        {
+            Id = 1,
+            SupplierID = 1,
+            Supplier = supplier
+        };
+
+        product.Supplier.Should().NotBeNull();
+        product.Supplier!.CompanyName.Should().Be("Acme Corp");
+    }
+
+    [Fact]
+    public void Category_ShouldBeSettable()
+    {
+        var category = new Category { Id = 1, CategoryName = "Beverages" };
+        var product = new Product
+        {
+            Id = 1,
+            CategoryID = 1,
+            Category = category
+        };
+
+        product.Category.Should().NotBeNull();
+        product.Category!.CategoryName.Should().Be("Beverages");
+    }
+
+    [Fact]
+    public void Discontinued_ShouldBeSettableToTrue()
+    {
+        var product = new Product { Discontinued = true };
+        product.Discontinued.Should().BeTrue();
+    }
+}

--- a/Tests/DotNetSamples.Tests/Models/ReportTests.cs
+++ b/Tests/DotNetSamples.Tests/Models/ReportTests.cs
@@ -1,0 +1,58 @@
+using EqDemo.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+
+namespace DotNetSamples.Tests.Models;
+
+public class ReportTests
+{
+    [Fact]
+    public void Properties_ShouldRoundTrip()
+    {
+        var report = new Report
+        {
+            Id = "rpt-001",
+            Name = "Monthly Sales",
+            Description = "Monthly sales report for Q1",
+            ModelId = "adhoc-reporting",
+            QueryJson = "{\"columns\":[\"OrderDate\",\"Total\"]}",
+            OwnerId = "user-123"
+        };
+
+        report.Id.Should().Be("rpt-001");
+        report.Name.Should().Be("Monthly Sales");
+        report.Description.Should().Be("Monthly sales report for Q1");
+        report.ModelId.Should().Be("adhoc-reporting");
+        report.QueryJson.Should().Contain("OrderDate");
+        report.OwnerId.Should().Be("user-123");
+    }
+
+    [Fact]
+    public void DefaultValues_ShouldBeNull()
+    {
+        var report = new Report();
+
+        report.Id.Should().BeNull();
+        report.Name.Should().BeNull();
+        report.Description.Should().BeNull();
+        report.ModelId.Should().BeNull();
+        report.QueryJson.Should().BeNull();
+        report.OwnerId.Should().BeNull();
+        report.Owner.Should().BeNull();
+    }
+
+    [Fact]
+    public void Owner_ShouldBeSettable()
+    {
+        var user = new IdentityUser { Id = "user-123", UserName = "test@test.com" };
+        var report = new Report
+        {
+            Id = "rpt-002",
+            OwnerId = user.Id,
+            Owner = user
+        };
+
+        report.Owner.Should().NotBeNull();
+        report.Owner!.UserName.Should().Be("test@test.com");
+    }
+}

--- a/Tests/DotNetSamples.Tests/Services/AppDbContextTests.cs
+++ b/Tests/DotNetSamples.Tests/Services/AppDbContextTests.cs
@@ -1,0 +1,398 @@
+using EqDemo;
+using EqDemo.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace DotNetSamples.Tests.Services;
+
+public class AppDbContextTests
+{
+    private AppDbContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public void CanCreateDatabase()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveCustomer()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var customer = new Customer
+        {
+            Id = "TEST1",
+            CompanyName = "Test Company",
+            ContactName = "Test Contact",
+            ContactTitle = "Owner",
+            Address = "123 Main St",
+            City = "Seattle",
+            Region = "WA",
+            PostalCode = "98101",
+            Country = "USA",
+            Phone = "555-1234",
+            Fax = "555-5678"
+        };
+
+        context.Customers.Add(customer);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Customers.FindAsync("TEST1");
+        retrieved.Should().NotBeNull();
+        retrieved!.CompanyName.Should().Be("Test Company");
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveProduct()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var product = new Product
+        {
+            Id = 1,
+            Name = "Test Product",
+            QuantityPerUnit = "10 boxes",
+            UnitPrice = 19.99m,
+            UnitsInStock = 50,
+            Discontinued = false
+        };
+
+        context.Products.Add(product);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Products.FindAsync(1);
+        retrieved.Should().NotBeNull();
+        retrieved!.Name.Should().Be("Test Product");
+        retrieved.UnitPrice.Should().Be(19.99m);
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveOrder()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var order = new Order
+        {
+            Id = 1,
+            OrderDate = new DateTime(2024, 1, 1),
+            Freight = 15.50m,
+            ShipName = "Test Shipment",
+            ShipAddress = "123 Main",
+            ShipCity = "Seattle",
+            ShipRegion = "WA",
+            ShipPostalCode = "98101",
+            ShipCountry = "USA",
+            CustomerID = ""
+        };
+
+        context.Orders.Add(order);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Orders.FindAsync(1);
+        retrieved.Should().NotBeNull();
+        retrieved!.Freight.Should().Be(15.50m);
+        retrieved.ShipCity.Should().Be("Seattle");
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveEmployee()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var employee = new Employee
+        {
+            Id = 1,
+            FirstName = "John",
+            LastName = "Doe",
+            Title = "Sales Rep",
+            TitleOfCourtesy = "Mr.",
+            Address = "123 Oak",
+            City = "Portland",
+            Region = "OR",
+            PostalCode = "97201",
+            Country = "USA",
+            HomePhone = "555-0001",
+            Extension = "1234",
+            PhotoPath = "/photos/john.jpg",
+            Notes = "Test employee",
+            Photo = Array.Empty<byte>()
+        };
+
+        context.Employees.Add(employee);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Employees.FindAsync(1);
+        retrieved.Should().NotBeNull();
+        retrieved!.FullName.Should().Be("John Doe");
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveReport()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var report = new Report
+        {
+            Id = "rpt-1",
+            Name = "Test Report",
+            Description = "A test report",
+            ModelId = "adhoc-reporting",
+            QueryJson = "{}",
+            OwnerId = "user-1"
+        };
+
+        context.Reports.Add(report);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Reports.FindAsync("rpt-1");
+        retrieved.Should().NotBeNull();
+        retrieved!.Name.Should().Be("Test Report");
+        retrieved.ModelId.Should().Be("adhoc-reporting");
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveCategory()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var category = new Category
+        {
+            Id = 1,
+            CategoryName = "Beverages",
+            Description = "Soft drinks, coffees, teas",
+            Picture = Array.Empty<byte>()
+        };
+
+        context.Categories.Add(category);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Categories.FindAsync(1);
+        retrieved.Should().NotBeNull();
+        retrieved!.CategoryName.Should().Be("Beverages");
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveSupplier()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var supplier = new Supplier
+        {
+            Id = 1,
+            CompanyName = "Acme Corp",
+            ContactName = "John Smith",
+            ContactTitle = "CEO",
+            Address = "100 Industry Blvd",
+            City = "Chicago",
+            Region = "IL",
+            PostalCode = "60601",
+            Country = "USA",
+            Phone = "312-555-0001",
+            Fax = "312-555-0002",
+            HomePage = "https://acme.example.com"
+        };
+
+        context.Suppliers.Add(supplier);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Suppliers.FindAsync(1);
+        retrieved.Should().NotBeNull();
+        retrieved!.CompanyName.Should().Be("Acme Corp");
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveShipper()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var shipper = new Shipper
+        {
+            Id = 1,
+            CompanyName = "Speedy Express",
+            Phone = "(503) 555-9831"
+        };
+
+        context.Shippers.Add(shipper);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Shippers.FindAsync(1);
+        retrieved.Should().NotBeNull();
+        retrieved!.CompanyName.Should().Be("Speedy Express");
+    }
+
+    [Fact]
+    public async Task CanQueryOrdersWithCustomerInclude()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var customer = new Customer
+        {
+            Id = "CUST1", CompanyName = "Test Corp",
+            ContactName = "Jane", ContactTitle = "Mgr",
+            Address = "1 St", City = "NYC", Region = "NY",
+            PostalCode = "10001", Country = "USA",
+            Phone = "555-0001", Fax = "555-0002"
+        };
+        var order = new Order
+        {
+            Id = 1, CustomerID = "CUST1", Customer = customer,
+            ShipName = "Ship1", ShipAddress = "2 St",
+            ShipCity = "NYC", ShipRegion = "NY",
+            ShipPostalCode = "10001", ShipCountry = "USA"
+        };
+
+        context.Customers.Add(customer);
+        context.Orders.Add(order);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Orders
+            .Include(o => o.Customer)
+            .FirstOrDefaultAsync(o => o.Id == 1);
+
+        retrieved.Should().NotBeNull();
+        retrieved!.Customer.Should().NotBeNull();
+        retrieved.Customer!.CompanyName.Should().Be("Test Corp");
+    }
+
+    [Fact]
+    public async Task CanQueryMultipleReportsForUser()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        context.Reports.AddRange(
+            new Report { Id = "r1", Name = "Report A", Description = "D", ModelId = "m1", OwnerId = "user-1", QueryJson = "{}" },
+            new Report { Id = "r2", Name = "Report B", Description = "D", ModelId = "m1", OwnerId = "user-1", QueryJson = "{}" },
+            new Report { Id = "r3", Name = "Report C", Description = "D", ModelId = "m1", OwnerId = "user-2", QueryJson = "{}" }
+        );
+        await context.SaveChangesAsync();
+
+        var userReports = await context.Reports
+            .Where(r => r.OwnerId == "user-1")
+            .OrderBy(r => r.Name)
+            .ToListAsync();
+
+        userReports.Should().HaveCount(2);
+        userReports[0].Name.Should().Be("Report A");
+        userReports[1].Name.Should().Be("Report B");
+    }
+
+    [Fact]
+    public async Task CanDeleteReport()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var report = new Report { Id = "r1", Name = "To Delete", Description = "D", ModelId = "m1", OwnerId = "u1", QueryJson = "{}" };
+        context.Reports.Add(report);
+        await context.SaveChangesAsync();
+
+        context.Reports.Remove(report);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Reports.FindAsync("r1");
+        retrieved.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CanUpdateReport()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var report = new Report { Id = "r1", Name = "Original", Description = "D", ModelId = "m1", OwnerId = "u1", QueryJson = "{}" };
+        context.Reports.Add(report);
+        await context.SaveChangesAsync();
+
+        report.Name = "Updated";
+        context.Reports.Update(report);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Reports.FindAsync("r1");
+        retrieved!.Name.Should().Be("Updated");
+    }
+
+    [Fact]
+    public async Task CanFilterProductsByCategory()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var cat1 = new Category { Id = 1, CategoryName = "Beverages", Description = "Drinks", Picture = Array.Empty<byte>() };
+        var cat2 = new Category { Id = 2, CategoryName = "Condiments", Description = "Sauces", Picture = Array.Empty<byte>() };
+        context.Categories.AddRange(cat1, cat2);
+
+        context.Products.AddRange(
+            new Product { Id = 1, Name = "Chai", CategoryID = 1, Category = cat1, QuantityPerUnit = "10" },
+            new Product { Id = 2, Name = "Chang", CategoryID = 1, Category = cat1, QuantityPerUnit = "24" },
+            new Product { Id = 3, Name = "Mustard", CategoryID = 2, Category = cat2, QuantityPerUnit = "12" }
+        );
+        await context.SaveChangesAsync();
+
+        var beverages = await context.Products
+            .Where(p => p.CategoryID == 1)
+            .ToListAsync();
+
+        beverages.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task CanFilterOrdersByDateRange()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        context.Orders.AddRange(
+            new Order { Id = 1, OrderDate = new DateTime(2024, 1, 1), ShipName = "S1", ShipAddress = "A1", ShipCity = "C1", ShipRegion = "R1", ShipPostalCode = "P1", ShipCountry = "US", CustomerID = "" },
+            new Order { Id = 2, OrderDate = new DateTime(2024, 3, 15), ShipName = "S2", ShipAddress = "A2", ShipCity = "C2", ShipRegion = "R2", ShipPostalCode = "P2", ShipCountry = "US", CustomerID = "" },
+            new Order { Id = 3, OrderDate = new DateTime(2024, 6, 1), ShipName = "S3", ShipAddress = "A3", ShipCity = "C3", ShipRegion = "R3", ShipPostalCode = "P3", ShipCountry = "US", CustomerID = "" }
+        );
+        await context.SaveChangesAsync();
+
+        var q1Orders = await context.Orders
+            .Where(o => o.OrderDate >= new DateTime(2024, 1, 1) && o.OrderDate < new DateTime(2024, 4, 1))
+            .ToListAsync();
+
+        q1Orders.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task OrderDetail_ShouldHaveCompositeKey()
+    {
+        using var context = CreateInMemoryContext();
+        context.Database.EnsureCreated();
+
+        var detail = new OrderDetail
+        {
+            OrderID = 1,
+            ProductID = 10,
+            UnitPrice = 14.00m,
+            Quantity = 12,
+            Discount = 0
+        };
+
+        context.OrderDetails.Add(detail);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.OrderDetails.FindAsync(1, 10);
+        retrieved.Should().NotBeNull();
+        retrieved!.UnitPrice.Should().Be(14.00m);
+    }
+}

--- a/Tests/DotNetSamples.Tests/Services/DefaultReportGeneratorTests.cs
+++ b/Tests/DotNetSamples.Tests/Services/DefaultReportGeneratorTests.cs
@@ -1,0 +1,185 @@
+using EqDemo;
+using EqDemo.Models;
+using EqDemo.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace DotNetSamples.Tests.Services;
+
+public class DefaultReportGeneratorTests
+{
+    private AppDbContext CreateContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        var ctx = new AppDbContext(options);
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    // The source code uses Path.Combine(contentRoot, "App_Data\\Seed") which
+    // on Linux creates a path with a literal backslash. We must match that.
+    private static string CreateSeedDir(string tempDir)
+    {
+        var seedDir = Path.Combine(tempDir, "App_Data\\Seed");
+        Directory.CreateDirectory(seedDir);
+        return seedDir;
+    }
+
+    [Fact]
+    public void Constructor_ShouldInitializeDataPath()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var context = CreateContext(dbName);
+
+        var env = new Mock<IWebHostEnvironment>();
+        env.Setup(e => e.ContentRootPath).Returns("/app");
+
+        var generator = new DefaultReportGenerator(env.Object, context);
+
+        generator.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ShouldAddReportsFromJsonFiles()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var context = CreateContext(dbName);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var seedDir = CreateSeedDir(tempDir);
+
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(seedDir, "report1.json"),
+                "{\"name\":\"Sales Report\",\"desc\":\"Monthly sales\"}"
+            );
+            File.WriteAllText(
+                Path.Combine(seedDir, "report2.json"),
+                "{\"name\":\"Inventory Report\",\"desc\":\"Current stock levels\"}"
+            );
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.ContentRootPath).Returns(tempDir);
+
+            var generator = new DefaultReportGenerator(env.Object, context);
+            var user = new IdentityUser { Id = "test-user-id", UserName = "test@test.com" };
+
+            await generator.GenerateAsync(user);
+
+            var reports = await context.Reports.ToListAsync();
+            reports.Should().HaveCount(2);
+            reports.Should().Contain(r => r.Name == "Sales Report");
+            reports.Should().Contain(r => r.Name == "Inventory Report");
+            reports.Should().OnlyContain(r => r.OwnerId == "test-user-id");
+            reports.Should().OnlyContain(r => r.ModelId == "adhoc-reporting");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ShouldSetUniqueIdsForEachReport()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var context = CreateContext(dbName);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var seedDir = CreateSeedDir(tempDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(seedDir, "a.json"), "{\"name\":\"A\",\"desc\":\"Desc A\"}");
+            File.WriteAllText(Path.Combine(seedDir, "b.json"), "{\"name\":\"B\",\"desc\":\"Desc B\"}");
+            File.WriteAllText(Path.Combine(seedDir, "c.json"), "{\"name\":\"C\",\"desc\":\"Desc C\"}");
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.ContentRootPath).Returns(tempDir);
+
+            var generator = new DefaultReportGenerator(env.Object, context);
+            var user = new IdentityUser { Id = "user-1" };
+
+            await generator.GenerateAsync(user);
+
+            var reports = await context.Reports.ToListAsync();
+            reports.Should().HaveCount(3);
+
+            var ids = reports.Select(r => r.Id).ToList();
+            ids.Should().OnlyHaveUniqueItems();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ShouldHandleEmptyDirectory()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var context = CreateContext(dbName);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var seedDir = CreateSeedDir(tempDir);
+
+        try
+        {
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.ContentRootPath).Returns(tempDir);
+
+            var generator = new DefaultReportGenerator(env.Object, context);
+            var user = new IdentityUser { Id = "user-1" };
+
+            await generator.GenerateAsync(user);
+
+            var reports = await context.Reports.ToListAsync();
+            reports.Should().BeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ShouldIncludeQueryJsonWithId()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using var context = CreateContext(dbName);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var seedDir = CreateSeedDir(tempDir);
+
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(seedDir, "test.json"),
+                "{\"name\":\"Test\",\"desc\":\"A test report\",\"columns\":[\"col1\"]}"
+            );
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.ContentRootPath).Returns(tempDir);
+
+            var generator = new DefaultReportGenerator(env.Object, context);
+            var user = new IdentityUser { Id = "user-1" };
+
+            await generator.GenerateAsync(user);
+
+            var report = await context.Reports.FirstAsync();
+            report.QueryJson.Should().Contain("\"id\":");
+            report.QueryJson.Should().Contain(report.Id);
+            report.QueryJson.Should().Contain("columns");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/Tests/DotNetSamples.Tests/Services/ReportCrudTests.cs
+++ b/Tests/DotNetSamples.Tests/Services/ReportCrudTests.cs
@@ -1,22 +1,20 @@
 using EqDemo;
 using EqDemo.Models;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Moq;
-using System.Security.Claims;
 
 namespace DotNetSamples.Tests.Services;
 
-public class ReportStoreTests
+public class ReportCrudTests
 {
-    private static AppDbContext CreateContext(string dbName)
+    private static AppDbContext CreateContext()
     {
         var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(dbName)
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
-        return new AppDbContext(options);
+        var ctx = new AppDbContext(options);
+        ctx.Database.EnsureCreated();
+        return ctx;
     }
 
     private static Report MakeReport(string id, string name, string modelId, string ownerId)
@@ -32,33 +30,10 @@ public class ReportStoreTests
         };
     }
 
-    private static (IServiceProvider, AppDbContext) CreateServices(string userId, string dbName)
-    {
-        var context = CreateContext(dbName);
-        context.Database.EnsureCreated();
-
-        var claims = new ClaimsPrincipal(new ClaimsIdentity(new[]
-        {
-            new Claim(ClaimTypes.NameIdentifier, userId)
-        }, "TestAuth"));
-
-        var httpContext = new DefaultHttpContext { User = claims };
-        var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
-
-        var services = new ServiceCollection();
-        services.AddSingleton(httpContextAccessor.Object);
-        services.AddSingleton(context);
-        var provider = services.BuildServiceProvider();
-
-        return (provider, context);
-    }
-
     [Fact]
-    public async Task ReportsCrudOperations_AddAndRetrieve()
+    public async Task AddAndRetrieve()
     {
-        var dbName = Guid.NewGuid().ToString();
-        var (_, context) = CreateServices("user-1", dbName);
+        using var context = CreateContext();
 
         var report = MakeReport("r1", "Sales Report", "adhoc-reporting", "user-1");
         context.Reports.Add(report);
@@ -71,10 +46,9 @@ public class ReportStoreTests
     }
 
     [Fact]
-    public async Task ReportsCrudOperations_UpdateReport()
+    public async Task UpdateReport()
     {
-        var dbName = Guid.NewGuid().ToString();
-        var (_, context) = CreateServices("user-1", dbName);
+        using var context = CreateContext();
 
         var report = MakeReport("r1", "Original", "m1", "user-1");
         context.Reports.Add(report);
@@ -91,10 +65,9 @@ public class ReportStoreTests
     }
 
     [Fact]
-    public async Task ReportsCrudOperations_DeleteReport()
+    public async Task DeleteReport()
     {
-        var dbName = Guid.NewGuid().ToString();
-        var (_, context) = CreateServices("user-1", dbName);
+        using var context = CreateContext();
 
         var report = MakeReport("r1", "To Delete", "m1", "user-1");
         context.Reports.Add(report);
@@ -108,10 +81,9 @@ public class ReportStoreTests
     }
 
     [Fact]
-    public async Task ReportsFiltering_ByOwner()
+    public async Task FilterByOwner()
     {
-        var dbName = Guid.NewGuid().ToString();
-        var (_, context) = CreateServices("user-1", dbName);
+        using var context = CreateContext();
 
         context.Reports.AddRange(
             MakeReport("r1", "Report A", "m1", "user-1"),
@@ -129,10 +101,9 @@ public class ReportStoreTests
     }
 
     [Fact]
-    public async Task ReportsFiltering_ByModelId()
+    public async Task FilterByModelId()
     {
-        var dbName = Guid.NewGuid().ToString();
-        var (_, context) = CreateServices("user-1", dbName);
+        using var context = CreateContext();
 
         context.Reports.AddRange(
             MakeReport("r1", "Report A", "model-1", "user-1"),
@@ -151,10 +122,9 @@ public class ReportStoreTests
     }
 
     [Fact]
-    public async Task ReportsFiltering_ByOwnerAndModel()
+    public async Task FilterByOwnerAndModel()
     {
-        var dbName = Guid.NewGuid().ToString();
-        var (_, context) = CreateServices("user-1", dbName);
+        using var context = CreateContext();
 
         context.Reports.AddRange(
             MakeReport("r1", "A", "m1", "user-1"),
@@ -171,16 +141,5 @@ public class ReportStoreTests
 
         results.Should().HaveCount(2);
         results.Select(r => r.Name).Should().ContainInOrder("A", "D");
-    }
-
-    [Fact]
-    public void HttpContextAccessor_ShouldResolveFromServices()
-    {
-        var (provider, _) = CreateServices("test-user", Guid.NewGuid().ToString());
-
-        var accessor = provider.GetService<IHttpContextAccessor>();
-        accessor.Should().NotBeNull();
-        accessor!.HttpContext.Should().NotBeNull();
-        accessor.HttpContext!.User.FindFirst(ClaimTypes.NameIdentifier)?.Value.Should().Be("test-user");
     }
 }

--- a/Tests/DotNetSamples.Tests/Services/ReportStoreTests.cs
+++ b/Tests/DotNetSamples.Tests/Services/ReportStoreTests.cs
@@ -1,0 +1,186 @@
+using EqDemo;
+using EqDemo.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Security.Claims;
+
+namespace DotNetSamples.Tests.Services;
+
+public class ReportStoreTests
+{
+    private static AppDbContext CreateContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static Report MakeReport(string id, string name, string modelId, string ownerId)
+    {
+        return new Report
+        {
+            Id = id,
+            Name = name,
+            Description = "Test description",
+            ModelId = modelId,
+            QueryJson = "{}",
+            OwnerId = ownerId
+        };
+    }
+
+    private static (IServiceProvider, AppDbContext) CreateServices(string userId, string dbName)
+    {
+        var context = CreateContext(dbName);
+        context.Database.EnsureCreated();
+
+        var claims = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId)
+        }, "TestAuth"));
+
+        var httpContext = new DefaultHttpContext { User = claims };
+        var httpContextAccessor = new Mock<IHttpContextAccessor>();
+        httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(httpContextAccessor.Object);
+        services.AddSingleton(context);
+        var provider = services.BuildServiceProvider();
+
+        return (provider, context);
+    }
+
+    [Fact]
+    public async Task ReportsCrudOperations_AddAndRetrieve()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (_, context) = CreateServices("user-1", dbName);
+
+        var report = MakeReport("r1", "Sales Report", "adhoc-reporting", "user-1");
+        context.Reports.Add(report);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Reports.FindAsync("r1");
+        retrieved.Should().NotBeNull();
+        retrieved!.Name.Should().Be("Sales Report");
+        retrieved.OwnerId.Should().Be("user-1");
+    }
+
+    [Fact]
+    public async Task ReportsCrudOperations_UpdateReport()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (_, context) = CreateServices("user-1", dbName);
+
+        var report = MakeReport("r1", "Original", "m1", "user-1");
+        context.Reports.Add(report);
+        await context.SaveChangesAsync();
+
+        report.Name = "Updated Report";
+        report.QueryJson = "{\"updated\":true}";
+        context.Reports.Update(report);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Reports.FindAsync("r1");
+        retrieved!.Name.Should().Be("Updated Report");
+        retrieved.QueryJson.Should().Contain("updated");
+    }
+
+    [Fact]
+    public async Task ReportsCrudOperations_DeleteReport()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (_, context) = CreateServices("user-1", dbName);
+
+        var report = MakeReport("r1", "To Delete", "m1", "user-1");
+        context.Reports.Add(report);
+        await context.SaveChangesAsync();
+
+        context.Reports.Remove(report);
+        await context.SaveChangesAsync();
+
+        var retrieved = await context.Reports.FindAsync("r1");
+        retrieved.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReportsFiltering_ByOwner()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (_, context) = CreateServices("user-1", dbName);
+
+        context.Reports.AddRange(
+            MakeReport("r1", "Report A", "m1", "user-1"),
+            MakeReport("r2", "Report B", "m1", "user-1"),
+            MakeReport("r3", "Report C", "m1", "user-2")
+        );
+        await context.SaveChangesAsync();
+
+        var user1Reports = await context.Reports
+            .Where(r => r.OwnerId == "user-1")
+            .ToListAsync();
+
+        user1Reports.Should().HaveCount(2);
+        user1Reports.Should().AllSatisfy(r => r.OwnerId.Should().Be("user-1"));
+    }
+
+    [Fact]
+    public async Task ReportsFiltering_ByModelId()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (_, context) = CreateServices("user-1", dbName);
+
+        context.Reports.AddRange(
+            MakeReport("r1", "Report A", "model-1", "user-1"),
+            MakeReport("r2", "Report B", "model-2", "user-1"),
+            MakeReport("r3", "Report C", "model-1", "user-1")
+        );
+        await context.SaveChangesAsync();
+
+        var model1Reports = await context.Reports
+            .Where(r => r.ModelId == "model-1")
+            .OrderBy(r => r.Name)
+            .ToListAsync();
+
+        model1Reports.Should().HaveCount(2);
+        model1Reports[0].Name.Should().Be("Report A");
+    }
+
+    [Fact]
+    public async Task ReportsFiltering_ByOwnerAndModel()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (_, context) = CreateServices("user-1", dbName);
+
+        context.Reports.AddRange(
+            MakeReport("r1", "A", "m1", "user-1"),
+            MakeReport("r2", "B", "m2", "user-1"),
+            MakeReport("r3", "C", "m1", "user-2"),
+            MakeReport("r4", "D", "m1", "user-1")
+        );
+        await context.SaveChangesAsync();
+
+        var results = await context.Reports
+            .Where(r => r.OwnerId == "user-1" && r.ModelId == "m1")
+            .OrderBy(r => r.Name)
+            .ToListAsync();
+
+        results.Should().HaveCount(2);
+        results.Select(r => r.Name).Should().ContainInOrder("A", "D");
+    }
+
+    [Fact]
+    public void HttpContextAccessor_ShouldResolveFromServices()
+    {
+        var (provider, _) = CreateServices("test-user", Guid.NewGuid().ToString());
+
+        var accessor = provider.GetService<IHttpContextAccessor>();
+        accessor.Should().NotBeNull();
+        accessor!.HttpContext.Should().NotBeNull();
+        accessor.HttpContext!.User.FindFirst(ClaimTypes.NameIdentifier)?.Value.Should().Be("test-user");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `Tests/DotNetSamples.Tests` xUnit test project with **56 unit tests** covering the testable business logic in `AdHocReporting.Server`.

**Coverage results** (via coverlet):
| Metric | Value |
|--------|-------|
| Line coverage | 36.9% |
| Branch coverage | 17.8% |
| Method coverage | 87.9% |
| Classes at 100% | 12 / 14 |

**What's tested:**
- **Models** (100% each): `Order.Name` formatting, `Employee.FullName` logic, `Product`, `Customer`, `OrderDetail`, `Report`, `Supplier`, `Shipper`, `Category` — property round-trips, computed properties, null handling, navigation properties
- **`AppDbContext`** (100%): CRUD for all entity types, `Include` queries, date range filtering, category filtering, composite key on `OrderDetail`, report owner filtering
- **`DefaultReportGenerator`** (100%): JSON seed file parsing via mocked `IWebHostEnvironment`, unique ID generation, empty directory handling, `QueryJson` content verification
- **Report CRUD patterns**: Add/update/delete reports, filter by `OwnerId`/`ModelId`

**Not covered** (and why):
- `ReportStore` — depends on `Korzh.EasyQuery.Services.IQueryStore`/`Query` types; would require deep mocking of third-party abstractions
- `DbInitializeExtensions` — static extension method tightly coupled to ASP.NET hosting pipeline (`IApplicationBuilder`, `UserManager`, `RoleManager`)
- `Program` — entry point, not unit-testable

**Test stack**: xUnit 2.5.3 + Moq 4.20.70 + FluentAssertions 6.12.0 + EF Core InMemory 8.0.5 + coverlet 6.0.0

Link to Devin session: https://app.devin.ai/sessions/703d020406d44c4a88e130d07a28afcc
Requested by: @tobydrinkall
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/DotNetSamples/pull/46?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/DotNetSamples/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/dotnetsamples/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->